### PR TITLE
Async functions of ingestion must be resolved in their respective blocks

### DIFF
--- a/client/StreamingIngestionSample/Program.cs
+++ b/client/StreamingIngestionSample/Program.cs
@@ -122,7 +122,7 @@ namespace StreamingIngestionSample
                         null, 
                         Kusto.Data.Common.DataSourceFormat.json, 
                         compressStream: false,
-                        mappingName: s_jsonMappingName);
+                        mappingName: s_jsonMappingName).GetAwaiter().GetResult();
                 }
             }
 
@@ -136,7 +136,7 @@ namespace StreamingIngestionSample
                     {
                         Format = DataSourceFormat.csv,
                     };
-                    ingestClient.IngestFromStreamAsync(data, ingestProperties);
+                    ingestClient.IngestFromStreamAsync(data, ingestProperties).GetAwaiter().GetResult();
                 }
 
                 using (var data = CreateSampleEventLogJsonStream(10))
@@ -147,7 +147,7 @@ namespace StreamingIngestionSample
                         JSONMappingReference = s_jsonMappingName
                     };
 
-                    ingestClient.IngestFromStreamAsync(data, ingestProperties);
+                    ingestClient.IngestFromStreamAsync(data, ingestProperties).GetAwaiter().GetResult();
                 }
 
             }


### PR DESCRIPTION
I was facing the below error message while running the streaming ingestion sample without any changes. 
```
ErrorMessage=Cannot access a closed Stream.
DataSource=https://<clusterName>.<clusterRegion>.kusto.windows.net/v1/rest/ingest/<dbName>/<tableName>?streamFormat=json&mappingName=<jsonMappingName>
DatabaseName=<dbName>
ClientRequestId=KD2StreamIngest; <guid> --->
System.ObjectDisposedException: Cannot access a closed Stream.
   at System.IO.Stream.CopyToAsync(Stream destination, Int32 bufferSize, CancellationToken cancellationToken)
   at System.Net.Http.StreamToStreamCopy.CopyAsync(Stream source, Stream destination, Int32 bufferSize, Boolean disposeSource, CancellationToken cancellationToken)
...
```
In one run, as I am understanding, 40 records are ingested by the sample as follows:

1. 10 records as CSV using Kusto.Data API.
2. 10 records as JSON using Kusto.Data API.
3. 10 records as CSV using Kusto.Ingest API.
4. 10 records as JSON using Kusto.Ingest API.

However, with current state of the example, only first call succeeds and 10 records are ingested correctly. The last 3 calls use async functions for ingesting streaming data which must be resolved in their respective `using` blocks to avoid error message as above. Please let me know if we can resolve this error using a better approach. 